### PR TITLE
prepare-doc: list available directories

### DIFF
--- a/scripts/prepare-doc.sh
+++ b/scripts/prepare-doc.sh
@@ -87,8 +87,10 @@ EOF
 
 if [ "$PARAVIEW_DOC_UPLOAD" = "true" ]; then
     cd "${WORK_DIR}/paraview-docs/"
+    ls
 
     if [ "$UPDATE_LATEST" = "true" ]; then
+      ls "$VERSION/"
       cp -r "$VERSION/*" latest/
     fi
 


### PR DESCRIPTION
When running on the nightly pipeline, the `nightly/` directory doesn't
exist for some reason. Look into the directory to see what the state is
before failing.