### PR TITLE
Fix undefined link suffix for v5.9 and v5.10

### DIFF
--- a/v5.10.0/python/_static/searchtools.js
+++ b/v5.10.0/python/_static/searchtools.js
@@ -265,7 +265,8 @@ var Search = {
         } else {
           // normal html builders
           requestUrl = DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX;
-          linkUrl = item[0] + DOCUMENTATION_OPTIONS.LINK_SUFFIX;
+          // If LINK_SUFFIX is undefined, default to ".html"
+          linkUrl = item[0] + (DOCUMENTATION_OPTIONS.LINK_SUFFIX || ".html");
         }
         listItem.append($('<a/>').attr('href',
             linkUrl +

--- a/v5.10.1/python/_static/searchtools.js
+++ b/v5.10.1/python/_static/searchtools.js
@@ -265,7 +265,8 @@ var Search = {
         } else {
           // normal html builders
           requestUrl = DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX;
-          linkUrl = item[0] + DOCUMENTATION_OPTIONS.LINK_SUFFIX;
+          // If LINK_SUFFIX is undefined, default to ".html"
+          linkUrl = item[0] + (DOCUMENTATION_OPTIONS.LINK_SUFFIX || ".html");
         }
         listItem.append($('<a/>').attr('href',
             linkUrl +

--- a/v5.9.0/python/_static/searchtools.js
+++ b/v5.9.0/python/_static/searchtools.js
@@ -265,7 +265,8 @@ var Search = {
         } else {
           // normal html builders
           requestUrl = DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX;
-          linkUrl = item[0] + DOCUMENTATION_OPTIONS.LINK_SUFFIX;
+          // If LINK_SUFFIX is undefined, default to ".html"
+          linkUrl = item[0] + (DOCUMENTATION_OPTIONS.LINK_SUFFIX || ".html");
         }
         listItem.append($('<a/>').attr('href',
             linkUrl +

--- a/v5.9.1/python/_static/searchtools.js
+++ b/v5.9.1/python/_static/searchtools.js
@@ -265,7 +265,8 @@ var Search = {
         } else {
           // normal html builders
           requestUrl = DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX;
-          linkUrl = item[0] + DOCUMENTATION_OPTIONS.LINK_SUFFIX;
+          // If LINK_SUFFIX is undefined, default to ".html"
+          linkUrl = item[0] + (DOCUMENTATION_OPTIONS.LINK_SUFFIX || ".html");
         }
         listItem.append($('<a/>').attr('href',
             linkUrl +


### PR DESCRIPTION
This issue was caused by too new of a version of sphinx being used with
too old of a version of sphinx_rtd_theme, for which we have a copy
residing in ParaView.

The older sphinx_rtd_theme was unaware of the
`DOCUMENTATION_OPTIONS.LINK_SUFFIX`, and it therefore was undefined.

This is the same fix performed in `fish-shell` in [this commit](https://github.com/fish-shell/fish-shell/commit/58885fbd0ba6b2b414bcf897f6226fe5419e2c05).

The issue would cause broken search result links, where clicking on a
link would include "undefined" in the url. This patch seems to fix the
issue.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>